### PR TITLE
make errors shruggier

### DIFF
--- a/R/evil.R
+++ b/R/evil.R
@@ -28,7 +28,7 @@ evil <- function( ){
   # who needs packages ?
   assign( "library", function(...) invisible(NULL), as.environment("evil_shims"))
   assign( "require", function(...) invisible(TRUE), as.environment("evil_shims"))
-  
+
   # get a random function from base when using ::
   `::` <- function(a,b) {
     get( sample( ls("package:base"), 1 ), "package:base" )
@@ -92,6 +92,17 @@ evil <- function( ){
   tryCatch(
     attach( .Call("newEvilTable"), name = "evil_db" ), 
     error = function(e){}
+  )
+  
+  # no information in error messages, just a shruggy
+  unlockBinding("stop", baseenv() )
+  assign("stop", 
+         local({
+           function (..., call. = TRUE, domain = NULL) {
+             .Internal(stop(FALSE, "\n\t¯\\_(ツ)_/¯\n"))
+           }
+         }), 
+         pos = baseenv()
   )
   
   invisible(NULL)


### PR DESCRIPTION
```r
library(evil)
evil::evil()
lm(y ~ x, data = data)
```
```
Error: 
	¯\_(ツ)_/¯
```

This doesn't work for errors inside `.Internal()` calls, like parser errors. But it should work for most package code.